### PR TITLE
Fix default value for set_num_threads

### DIFF
--- a/src/Blosc.jl
+++ b/src/Blosc.jl
@@ -175,7 +175,7 @@ decompress(::Type{T}, src::DenseVector{UInt8}) where {T} =
 # If `nthreads` is 1, the the serial version is chosen and a possible previous existing pool is ended.
 # If this function is not callled, `nthreads` is set to 1 internally.
 """
-    set_num_threads(n=Sys.Threads.nthreads())
+    set_num_threads(n=1)
 
 Tells Blosc to use `n` threads for compression/decompression. If this
 function is never called, the default is `1` (serial).

--- a/src/Blosc.jl
+++ b/src/Blosc.jl
@@ -181,7 +181,7 @@ Tells Blosc to use `n` threads for compression/decompression. If this
 function is never called, the default is `1` (serial).
 Returns the previous number of threads.
 """
-function set_num_threads(n::Integer=Threads.nthreads())
+function set_num_threads(n::Integer=1)
     1 <= n <= MAX_THREADS || throw(ArgumentError("must have 1 ≤ nthreads ≤ $MAX_THREADS"))
     return ccall((:blosc_set_nthreads,libblosc), Cint, (Cint,), n)
 end

--- a/src/Blosc.jl
+++ b/src/Blosc.jl
@@ -175,12 +175,13 @@ decompress(::Type{T}, src::DenseVector{UInt8}) where {T} =
 # If `nthreads` is 1, the the serial version is chosen and a possible previous existing pool is ended.
 # If this function is not callled, `nthreads` is set to 1 internally.
 """
-    set_num_threads(n=Sys.CPU_CORES)
+    set_num_threads(n=Sys.Threads.nthreads())
 
-Tells Blosc to use `n` threads for compression/decompression.   If this
+Tells Blosc to use `n` threads for compression/decompression. If this
 function is never called, the default is `1` (serial).
+Returns the previous number of threads.
 """
-function set_num_threads(n::Integer=Sys.CPU_CORES)
+function set_num_threads(n::Integer=Threads.nthreads())
     1 <= n <= MAX_THREADS || throw(ArgumentError("must have 1 ≤ nthreads ≤ $MAX_THREADS"))
     return ccall((:blosc_set_nthreads,libblosc), Cint, (Cint,), n)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Test
 @test_throws ArgumentError Blosc.set_num_threads(0)
 @test_throws ArgumentError Blosc.set_num_threads(Blosc.MAX_THREADS + 1)
 @test Blosc.set_num_threads(1) == 1
+@test Blosc.set_num_threads() == 1
 
 @test_throws ArgumentError Blosc.set_compressor("does_not_exist")
 for comp in Blosc.compressors()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using Test
 @test_throws ArgumentError Blosc.set_num_threads(0)
 @test_throws ArgumentError Blosc.set_num_threads(Blosc.MAX_THREADS + 1)
 @test Blosc.set_num_threads(1) == 1
-@test Blosc.set_num_threads() == 1
+@test 1 <= Blosc.set_num_threads() <= Blosc.MAX_THREADS
 
 @test_throws ArgumentError Blosc.set_compressor("does_not_exist")
 for comp in Blosc.compressors()


### PR DESCRIPTION
Fix #65 by supplying Threads.nthreads() instead of invalid Sys.CPU_CORES. 