### PR TITLE
docstring typo

### DIFF
--- a/src/Blosc.jl
+++ b/src/Blosc.jl
@@ -190,7 +190,7 @@ end
 
 Set the current compression algorithm to `s`.  The currently supported
 algorithms in the default Blosc module build are `"blosclz"`, `"lz4"`,
-and `"l4hc"`.   (Throws an `ArgumentError` if `s` is not the name
+and `"lz4hc"`.   (Throws an `ArgumentError` if `s` is not the name
 of a supported algorithm.)  Returns a nonnegative integer code used
 internally by Blosc to identify the compressor.
 """


### PR DESCRIPTION
```julia
julia> Blosc.set_compressor("l4hc")
ERROR: ArgumentError: unrecognized compressor l4hc
Stacktrace:
 [1] set_compressor(::String) at /Users/milan/.julia/packages/Blosc/Six7M/src/Blosc.jl:199
 [2] top-level scope at none:0

julia> Blosc.set_compressor("lz4hc")
2
```